### PR TITLE
IOF club export - export Id if ExternalId is not provided (fixes #15)

### DIFF
--- a/code/iof30interface.cpp
+++ b/code/iof30interface.cpp
@@ -2918,6 +2918,8 @@ void IOF30Interface::writeClub(xmlparser &xml, const oClub &c, bool writeExtende
   __int64 id = c.getExtIdentifier();
   if (id != 0)
     xml.write("Id", c.getExtIdentifierString());
+  else
+    xml.write("Id", c.getId());
 
   xml.write("Name", c.getName());
   wstring sname = c.getDCI().getString("ShortName");


### PR DESCRIPTION
When exporting clubs to IOF XML format, if ExternalId is not provided (in case like club entered manualy), add Id to the XML.
This makes it possible to create a persons/clubs db from scratch in MEOS and export/import it between competitions.