### PR TITLE
Localise event dates when retrieving competition list from Eventor

### DIFF
--- a/code/TabCompetition.cpp
+++ b/code/TabCompetition.cpp
@@ -2994,7 +2994,8 @@ void TabCompetition::getEventorCompetitions(gdioutput &gdi,
         dayOffset = 1;
       }
       ci.firstStart = formatTimeHMS(nt, SubSecond::Off);
-      //TODO: Take dayoffset into account
+      if (dayOffset)
+        ci.Date = addOrSubtractDays(ci.Date, dayOffset);
     }
 
     xmlEvents[k].getObjectString("WebURL", ci.url);

--- a/code/meos_util.cpp
+++ b/code/meos_util.cpp
@@ -2555,3 +2555,32 @@ const string &codeRelativeTime(int rt) {
   res = bf;
   return res;
 }
+
+wstring addOrSubtractDays(const wstring& m, int days) {
+  // Convert wstring date to SYSTEMTIME
+  SYSTEMTIME st;
+  convertDateYMD(m, st, false);
+
+  // Convert SYSTEMTIME to FILETIME
+  FILETIME ft;
+  SystemTimeToFileTime(&st, &ft);
+
+  // Convert FILETIME to ULARGE_INTEGER for arithmetic
+  ULARGE_INTEGER ui;
+  ui.LowPart = ft.dwLowDateTime;
+  ui.HighPart = ft.dwHighDateTime;
+
+  // Add/subtract the number of days in 100-nanosecond intervals
+  const LONGLONG intervals_per_day = 24 * timeConstSecPerHour * static_cast<LONGLONG>(10000000);
+  ui.QuadPart += days * intervals_per_day;
+
+  // Convert back to FILETIME
+  ft.dwLowDateTime = ui.LowPart;
+  ft.dwHighDateTime = ui.HighPart;
+
+  // Convert FILETIME back to SYSTEMTIME
+  SYSTEMTIME new_st;
+  FileTimeToSystemTime(&ft, &new_st);
+
+  return convertSystemDate(new_st);
+}

--- a/code/meos_util.h
+++ b/code/meos_util.h
@@ -128,6 +128,9 @@ int convertAbsoluteTimeHMS(const string &m, int daysZeroTime);
 */
 int convertAbsoluteTimeHMS(const wstring &m, int daysZeroTime);
 
+// Add or subtract a number of days from a date in Y-M-D format
+wstring addOrSubtractDays(const wstring& m, int days);
+
 const vector<string> &split(const string &line, const string &separators, vector<string> &split_vector);
 
 const vector<wstring> &split(const wstring &line, const wstring &separators, vector<wstring> &split_vector);


### PR DESCRIPTION
It looks as though this was a TODO.
For countries on a different time-zone it was possible for the dates shown for competitions retrieved from Eventor to be out by a day. This pull request addresses that small problem.