### PR TITLE
Expose event ID in Information Server REST API status endpoint

### DIFF
--- a/code/infoserver.cpp
+++ b/code/infoserver.cpp
@@ -86,6 +86,7 @@ InfoClass::InfoClass(int id) : InfoBase(id) {
 }
 
 InfoMeosStatus::InfoMeosStatus() : InfoBase(0) {
+  eventId = 0;
 }
 
 InfoOrganization::InfoOrganization(int id) : InfoBase(id) {
@@ -489,6 +490,7 @@ void InfoMeosStatus::serialize(xmlbuffer &xml, bool diffOnly) const {
   prop.push_back(make_pair("version", getMeosCompectVersion()));
   prop.push_back(make_pair("eventNameId", eventNameId));
   prop.push_back(make_pair("onDatabase", itow(onDatabase)));		// 1 is true, 0 is false
+  prop.push_back(make_pair("eventId", itow(eventId)));
 
   xml.write("status", prop, L"");
 }

--- a/code/infoserver.h
+++ b/code/infoserver.h
@@ -137,12 +137,14 @@ class InfoMeosStatus : public InfoBase {
   protected:
     wstring eventNameId; // event Name Id, actual name of the database, can also be matched in oevent table of meosmain
     bool onDatabase; // true if currently on database
+    int eventId; // numeric event id, used for UDP DirectSocket filtering
   public:
     void serialize(xmlbuffer &xml, bool diffOnly) const;
     InfoMeosStatus();
     virtual ~InfoMeosStatus() {}
     void setEventNameId(const wstring &);
     void setOnDatabase(const bool);
+    void setEventId(int id) { eventId = id; }
 };
 
 class InfoOrganization : public InfoBase {

--- a/code/restserver.cpp
+++ b/code/restserver.cpp
@@ -986,10 +986,12 @@ void RestServer::getData(oEvent &oe, const string &what, const multimap<string, 
     if (oe.empty()) {
       iStatus.setEventNameId(L"");	// no event
       iStatus.setOnDatabase(false);
+      iStatus.setEventId(0);
     }
     else {
       iStatus.setEventNameId(oe.getNameId(0));	// id of event
       iStatus.setOnDatabase(oe.isClient());	// onDatabase
+      iStatus.setEventId(oe.getId());
     }
 
     iStatus.serialize(out, false);


### PR DESCRIPTION
Add eventId attribute to the /meos?get=status response. This is the numeric competition ID (oEvent::getId()) used by DirectSocket for UDP broadcast filtering. External applications can use this value to filter UDP packets when multiple competitions share the same network and port.