### PR TITLE
Resolved Issue #114 - added 6 new variables visible from the Meos cus…

### DIFF
--- a/code/generalresult.cpp
+++ b/code/generalresult.cpp
@@ -1066,7 +1066,14 @@ void DynamicResult::declareSymbols(DynamicMethods m, bool clear) const {
   }
 
   parser.declareSymbol("MaxTime", "Maximum allowed running time", false);
-
+  //EST20260629 START Issue #114
+  parser.declareSymbol("RPointLimit", "Rogaining Point Limit", false);
+  parser.declareSymbol("RTimeLimit", "Rogaining Time Limit", false);
+  parser.declareSymbol("RogainingType", "Type of Rogaining: 0, 1 or 2", false);
+  parser.declareSymbol("RPointsPerMin", "Point reduction per minute", false);
+  parser.declareSymbol("RReductionMethod", "1 = on started minute", false);
+  parser.declareSymbol("RLatepoints", "1 = if allowed to collect after", false);
+  //EST20260629 END
   parser.declareSymbol("StatusUnknown", "Status code for an unknown result", false);
   parser.declareSymbol("StatusOK", "Status code for a valid result", false);
   parser.declareSymbol("StatusMP", "Status code for a missing punch", false);
@@ -1369,6 +1376,16 @@ void DynamicResult::prepareCalculations(oRunner &runner, bool classResult) const
   }
 
   pCourse crs = runner.getCourse(true);
+  //EST20260629 START Issue #114
+  parser.addSymbol("RTimeLimit", crs->getDCI().getInt("RTimeLimit") / timeConstSecond);
+  parser.addSymbol("RPointLimit", crs->getDCI().getInt("RPointLimit"));
+  parser.addSymbol("RogainingType", crs->getRogainingType());
+  parser.addSymbol("RPointsPerMin", crs->getRogainingPointsPerMinute());
+  parser.addSymbol("RReductionMethod", crs->getDCI().getInt("RReductionMethod"));
+  // Only show "collect late points" if it is time-based rogaining
+  parser.addSymbol("RLatepoints", (crs->getRogainingType() == 1) ? ((crs->getDCI().getInt("NoLatePoints") == 1) ? 0 : 1) : 0);
+  
+  //EST20260629 END
   const vector<SplitData> &sp = runner.getSplitTimes(false);
 
   if (crs) {

--- a/code/oCourse.cpp
+++ b/code/oCourse.cpp
@@ -938,6 +938,18 @@ bool oCourse::hasRogaining() const {
   cachedHasRogaining = r ? 2 : 1;
   return r;
 }
+// EST20260629 START Issue #114
+
+// returns 1 if Rogaining type is time limit, 2 if point limit, else 0
+
+int oCourse::getRogainingType() const {
+    if (getMaximumRogainingTime() > 0)
+        return 1;
+    else if (getMinimumRogainingPoints() > 0)
+        return 2;
+    return 0;
+}
+// EST20260629 END
 
 void oCourse::clearCache() const {
   cachedHasRogaining = 0;

--- a/code/oCourse.h
+++ b/code/oCourse.h
@@ -187,6 +187,11 @@ public:
   /// Return true if the course has rogaining
   bool hasRogaining() const;
 
+  /// EST20260629 START Issue #114
+  /// Return type of rogaining (time or points)
+  int getRogainingType() const;
+  /// EST20260629 END
+
   // Get the control number as "printed on map". Do not count
   // rogaining controls
   const wstring &getControlOrdinal(int controlIndex) const;

--- a/code/oRunner.cpp
+++ b/code/oRunner.cpp
@@ -6965,7 +6965,7 @@ int oRunner::getRogainingPointsGross(bool computed) const {
   if (computed) {
     int cmp = getRogainingPoints(computed, false);
     if (cmp > 0)
-      return cmp + tReduction; // This formula only holds when something remains. If tRediction > collected points, the result is wrong
+      return cmp + tReduction; // This formula only holds when something remains. If tReduction > collected points, the result is wrong
     else
       return tRogainingPointsGross;
   }


### PR DESCRIPTION
Hi, this PR adds 6 new variables to the MeOS custom results module.  These are:
RogainingType - 0 if user's course is not rogaining type, 1 if it is time limit based, 2 if it is point limit based.
RTimeLimit - the maximum time permitted for this rogaine before deductions occur (in seconds)
RPointLimit - the minimum number of points that must be achieved
RPointsPerMinute - if RTimeLimit, the number of points to be deducted per minute late
RReductionMethod - 1 if reduction for each started minute, 0 otherwise
RLatePoints - 1 if allowed to collect points after RTimeLimit has been reached